### PR TITLE
Remove unused For and Unary Expression

### DIFF
--- a/Ast.cc
+++ b/Ast.cc
@@ -1,5 +1,8 @@
-/********************************************************************/
-
+/*
+  Filename   : Ast.cc
+  Author     : Eric Dougherty & Ian Murry
+  Course     : CSCI 435
+*/
 
 /********************************************************************/
 // Local Includes
@@ -151,24 +154,6 @@ IfStatementNode::~IfStatementNode ()
 
 void
 IfStatementNode::accept (IVisitor* visitor)
-{
-  visitor -> visit (this);
-}
-
-/********************************************************************/
-
-ForStatementNode::ForStatementNode (ExpressionNode* e1,
-                    ExpressionNode* e2,
-                    ExpressionNode* e3,
-                    StatementNode* s)
-  :initializer (e1), condition (e2), updater (e3), body (s)
-{}
-
-ForStatementNode::~ForStatementNode ()
-{}
-
-void
-ForStatementNode::accept (IVisitor* visitor)
 {
   visitor -> visit (this);
 }
@@ -339,21 +324,6 @@ RelationalExpressionNode::~RelationalExpressionNode ()
 
 void
 RelationalExpressionNode::accept (IVisitor* visitor)
-{
-  visitor -> visit (this);
-}
-
-/********************************************************************/
-UnaryExpressionNode::UnaryExpressionNode (UnaryOperatorType unaryOp,
-               VariableExpressionNode* var)
-  :unaryOperator (unaryOp), variable (var)
-{}
-
-UnaryExpressionNode::~UnaryExpressionNode ()
-{}
-
-void
-UnaryExpressionNode::accept (IVisitor* visitor)
 {
   visitor -> visit (this);
 }

--- a/Ast.h
+++ b/Ast.h
@@ -1,3 +1,8 @@
+/*
+  Filename   : Ast.h
+  Author     : Eric Dougherty & Ian Murry
+  Course     : CSCI 435
+*/
 
 /********************************************************************/
 // C- AST Header File
@@ -44,7 +49,6 @@ struct StatementNode;
 struct CompoundStatementNode;
 struct IfStatementNode;
 struct WhileStatementNode;
-struct ForStatementNode;
 struct ReturnStatementNode;
 struct ExpressionStatementNode;
 
@@ -57,7 +61,6 @@ struct CallExpressionNode;
 struct AdditiveExpressionNode;
 struct MultiplicativeExpressionNode;
 struct RelationalExpressionNode;
-struct UnaryExpressionNode;
 struct IntegerLiteralExpressionNode;
 
 /********************************************************************/
@@ -237,24 +240,6 @@ struct WhileStatementNode : StatementNode
   StatementNode* body;
 };
 
-struct ForStatementNode : StatementNode
-{
-  ForStatementNode (ExpressionNode* e1,
-                    ExpressionNode* e2,
-                    ExpressionNode* e3,
-                    StatementNode* s);
-
-  ~ForStatementNode ();
-
-  void
-  accept (IVisitor* visitor);
-
-  ExpressionNode* initializer;
-  ExpressionNode* condition;
-  ExpressionNode* updater;
-  StatementNode*  body;
-};
-
 struct ReturnStatementNode : StatementNode
 {
   ReturnStatementNode (ExpressionNode* expr = nullptr);
@@ -387,21 +372,6 @@ struct RelationalExpressionNode : ExpressionNode
   RelationalOperatorType relationalOperator;
   ExpressionNode* left;
   ExpressionNode* right;
-};
-
-
-struct UnaryExpressionNode : ExpressionNode
-{
-  UnaryExpressionNode (UnaryOperatorType unaryOp,
-                       VariableExpressionNode* var);
-
-  ~UnaryExpressionNode ();
-
-  void
-  accept (IVisitor* visitor);
-
-  UnaryOperatorType unaryOperator;
-  VariableExpressionNode* variable;
 };
 
 struct IntegerLiteralExpressionNode : ExpressionNode

--- a/Driver.cc
+++ b/Driver.cc
@@ -1,8 +1,7 @@
 /*
   Filename   : Driver.cc
-  Author     : Eric Dougherty
+  Author     : Eric Dougherty & Ian Murry
   Course     : CSCI 435
-  Assignment : Lab 9 - Can't Parse This
 */
 
 /************************************************************/

--- a/Parser.cc
+++ b/Parser.cc
@@ -2,23 +2,22 @@
   Filename   : Parser.cc
   Author     : Eric Dougherty
   Course     : CSCI 435
-  Assignment : Lab 9 - Can't Parse This
 */
 
-/***********************************************************************/
+/********************************************************************/
 // System includes
 
 #include <iostream>
 #include <fstream>
 
-/***********************************************************************/
+/********************************************************************/
 // Local includes
 
 #include "Parser.h"
 #include "Ast.h"
 #include "Visitor.h"
 
-/***********************************************************************/
+/********************************************************************/
 // Using declarations
 
 using std::string;
@@ -26,14 +25,14 @@ using std::cout;
 using std::endl;
 using std::ofstream;
 
-/***********************************************************************/
+/********************************************************************/
 // Function prototypes/global vars/typedefs
 
 Parser::Parser (FILE* file)
     :m_lexer (Lexer(file)), m_matchedID(false), ast (ProgramNode())
 { }
 
-/***********************************************************************/
+/********************************************************************/
 
 bool
 Parser::parse ()
@@ -44,7 +43,7 @@ Parser::parse ()
 	return true;
 }
 
-/***********************************************************************/
+/********************************************************************/
 
 void
 Parser::print (string name)
@@ -55,7 +54,7 @@ Parser::print (string name)
 	visitor.file.close ();
 }
 
-/***********************************************************************/
+/********************************************************************/
 
 void 
 Parser::declarations (auto parent)
@@ -296,13 +295,13 @@ Parser::expression ()
 		}
 		else 
 		{
-			m_varNode = var (m_callID);
+			VariableExpressionNode* varNode = m_varNode = var (m_callID);
 
 			if (m_token.type == ASSIGN)
 			{
 				match (ASSIGN, "=", "expression");
 				ExpressionNode* exprNode = expression ();
-				return new AssignmentExpressionNode (m_varNode, exprNode);
+				return new AssignmentExpressionNode (varNode, exprNode);
 			}
 			else
 			{
@@ -508,7 +507,7 @@ Parser::argList (vector<ExpressionNode*> & args)
 	}
 }
 
-/***********************************************************************/
+/********************************************************************/
 
 string 
 Parser::match (Token expectedToken, string possibleTokens, string caller)

--- a/Parser.h
+++ b/Parser.h
@@ -2,7 +2,6 @@
   Filename   : Parser.h
   Author     : Eric Dougherty
   Course     : CSCI 435
-  Assignment : Lab 9 - Can't Parse This
 */
 
 /***********************************************************************/

--- a/Visitor.cc
+++ b/Visitor.cc
@@ -1,12 +1,15 @@
-/********************************************************************/
-
+/*
+  Filename   : Visitor.cc
+  Author     : Eric Dougherty & Ian Murry
+  Course     : CSCI 435
+*/
 
 /********************************************************************/
 // System Includes
 
 #include <iostream>
 
-/***********************************************************************/
+/********************************************************************/
 // Local includes
 
 #include "Visitor.h"
@@ -102,19 +105,6 @@ PrintVisitor::visit (IfStatementNode* node)
   node -> conditionalExpression -> accept (this);
   node -> thenStatement -> accept (this);
   node -> elseStatement -> accept (this);
-  --level;
-}
-
-void
-PrintVisitor::visit (ForStatementNode* node)
-{
-  ++level;
-  printLevel ();
-  file << "For" << endl;
-  node -> initializer -> accept (this);
-  node -> condition -> accept (this);
-  node -> updater -> accept (this);
-  node -> body -> accept (this);
   --level;
 }
 
@@ -242,20 +232,8 @@ PrintVisitor::visit (RelationalExpressionNode* node)
   case RelationalOperatorType::NEQ:
     op = "!=";
     break;
-  case RelationalOperatorType::ERROR:
-    exit (1);
   }
   printArithmeticInfo ("RelationalExpression", op, node);
-}
-
-void
-PrintVisitor::visit (UnaryExpressionNode* node)
-{
-  ++level;    
-  printLevel ();
-  //file << node -> unaryOperator;
-  file << node -> variable << endl;
-  --level;
 }
 
 void
@@ -266,6 +244,8 @@ PrintVisitor::visit (IntegerLiteralExpressionNode* node)
   file << "Integer: "<< node -> value << endl;
   --level;
 }
+
+/********************************************************************/
 
 void
 PrintVisitor::printNodeInfo (string nodeType, auto node)
@@ -294,6 +274,6 @@ PrintVisitor::printLevel ()
 {
   for (size_t i = 0; i < level; ++i)
   {
-    file << "  ";
+    file << "|  ";
   }
 }

--- a/Visitor.h
+++ b/Visitor.h
@@ -1,5 +1,11 @@
+/*
+  Filename   : Visitor.h
+  Author     : Eric Dougherty & Ian Murry
+  Course     : CSCI 435
+*/
+
 /********************************************************************/
-// C- AST Header File
+// C- Visitor Header File
 // Design by CSCI 435: Compilers class
 // Fall 2014
 // Fall 2016
@@ -7,7 +13,7 @@
 #ifndef VISITOR_H
 #define VISITOR_H
 
-/***********************************************************************/
+/********************************************************************/
 // System includes
 
 #include <fstream>
@@ -17,7 +23,7 @@
 
 #include "Ast.h"
 
-/***********************************************************************/
+/********************************************************************/
 // Using declarations
 
 using std::ofstream;
@@ -40,7 +46,6 @@ public:
   virtual void visit (CompoundStatementNode* node) = 0;
   virtual void visit (IfStatementNode* node) = 0;
   virtual void visit (WhileStatementNode* node) = 0;
-  virtual void visit (ForStatementNode* node) = 0;
   virtual void visit (ReturnStatementNode* node) = 0;
   virtual void visit (ExpressionStatementNode* node) = 0;
 
@@ -52,7 +57,6 @@ public:
   virtual void visit (AdditiveExpressionNode* node) = 0;
   virtual void visit (MultiplicativeExpressionNode* node) = 0;
   virtual void visit (RelationalExpressionNode* node) = 0;
-  virtual void visit (UnaryExpressionNode* node) = 0;
   virtual void visit (IntegerLiteralExpressionNode* node) = 0;
 };
 
@@ -71,8 +75,7 @@ public:
   virtual void visit (StatementNode* node){}; 
   virtual void visit (CompoundStatementNode* node); 
   virtual void visit (IfStatementNode* node); 
-  virtual void visit (WhileStatementNode* node); 
-  virtual void visit (ForStatementNode* node); 
+  virtual void visit (WhileStatementNode* node);
   virtual void visit (ReturnStatementNode* node); 
   virtual void visit (ExpressionStatementNode* node); 
 
@@ -83,8 +86,7 @@ public:
   virtual void visit (CallExpressionNode* node); 
   virtual void visit (AdditiveExpressionNode* node); 
   virtual void visit (MultiplicativeExpressionNode* node);
-  virtual void visit (RelationalExpressionNode* node); 
-  virtual void visit (UnaryExpressionNode* node); 
+  virtual void visit (RelationalExpressionNode* node);
   virtual void visit (IntegerLiteralExpressionNode* node); 
 
   void 


### PR DESCRIPTION
-Added local varNode to expression() in Parser.cc for cases where a var occurs on both sides of assignment